### PR TITLE
Removing desktop launch

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,8 +25,8 @@ package-repositories:
 apps:
   btop:
     command: usr/local/bin/btop
-    extensions:
-      - gnome-3-38 
+#    extensions:
+#      - gnome-3-38 
     environment:
       LC_ALL: C.UTF-8
       LANG: C.UTF-8
@@ -39,11 +39,11 @@ apps:
       - network-observe
       - home
       - removable-media
-      - desktop
-      - desktop-legacy
-      - x11
-      - wayland
-      - unity7
+#      - desktop
+#      - desktop-legacy
+#      - x11
+#      - wayland
+#      - unity7
 
 parts:
   btop:


### PR DESCRIPTION
Users mentioned dramatically increased size as a potential problem. I may entertain a separate snap for desktops and this original for servers/simplified deployments.