### PR TITLE
add additional metadata to the snap distribution

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,4 +1,13 @@
 name: btop
+title: btop++
+contact: https://github.com/aristocratos/btop/issues
+issues: https://github.com/aristocratos/btop/issues
+donation:
+  - https://github.com/sponsors/aristocratos
+  - https://ko-fi.com/aristocratos
+  - https://www.paypal.com/paypalme/aristocratos
+source-code: https://github.com/aristocratos/btop
+website: https://github.com/aristocratos/btop
 adopt-info: btop
 summary: Resource monitor that shows usage and stats
 description: |


### PR DESCRIPTION
This patch resolves the following linter warning/info messages:

```
Lint warnings:
- metadata: Metadata field 'title' is missing or empty. (https://documentation.ubuntu.com/snapcraft/stable/reference/project-file/snapcraft-yaml/#title)
- metadata: Metadata field 'contact' is missing or empty. (https://documentation.ubuntu.com/snapcraft/stable/reference/project-file/snapcraft-yaml/#contact)
Lint information:
- metadata: Metadata field 'donation' is missing or empty. (https://documentation.ubuntu.com/snapcraft/stable/reference/project-file/snapcraft-yaml/#donation)
- metadata: Metadata field 'issues' is missing or empty. (https://documentation.ubuntu.com/snapcraft/stable/reference/project-file/snapcraft-yaml/#issues)
- metadata: Metadata field 'source-code' is missing or empty. (https://documentation.ubuntu.com/snapcraft/stable/reference/project-file/snapcraft-yaml/#source-code)
- metadata: Metadata field 'website' is missing or empty. (https://documentation.ubuntu.com/snapcraft/stable/reference/project-file/snapcraft-yaml/#website)
```

All the information of the application is sourced from the GitHub page.